### PR TITLE
feat(d2): param models, registry validation, and CLI offline validate

### DIFF
--- a/browser_agent/actions/params.py
+++ b/browser_agent/actions/params.py
@@ -1,0 +1,52 @@
+"""
+入参模型: 定义基础五个动作的 Pydantic v2 参数约束。
+Why: 在 LLM → 执行器 的边界先做强校验, 拦截坏数据, 统一错误结构。
+包含:
+- OpenUrlParams { url: AnyHttpUrl }
+- WaitForParams { selector: NonEmptyStr, timeout_ms?: TimeoutMs<=60000 }
+- ClickParams { selector: NonEmptyStr }
+- TypeParams { selector: NonEmptyStr, text: TextLimited<=4000 }
+- ExtractTextParams { selector: NonEmptyStr }
+"""
+# @file purpose: Define parameter schemas for core actions using Pydantic v2.
+
+from typing import Annotated
+
+from pydantic import AnyHttpUrl, BaseModel, Field
+
+# 辅助约束类型
+NonEmptyStr = Annotated[str, Field(min_length=1, strip_whitespace=True)]
+TimeoutMs = Annotated[int, Field(gt=0, le=60_000)]
+TextLimited = Annotated[str, Field(max_length=4000)]
+
+
+class OpenUrlParams(BaseModel):
+    """Parameters for open_url action."""
+
+    url: AnyHttpUrl
+
+
+class WaitForParams(BaseModel):
+    """Parameters for wait_for action."""
+
+    selector: NonEmptyStr
+    timeout_ms: TimeoutMs | None = 10_000
+
+
+class ClickParams(BaseModel):
+    """Parameters for click action."""
+
+    selector: NonEmptyStr
+
+
+class TypeParams(BaseModel):
+    """Parameters for type action."""
+
+    selector: NonEmptyStr
+    text: TextLimited
+
+
+class ExtractTextParams(BaseModel):
+    """Parameters for extract_text action."""
+
+    selector: NonEmptyStr


### PR DESCRIPTION
## Description

### Background / Goal

Establish a **hard boundary** between LLM output and browser execution. All actions must pass strict parameter validation **before** they run. Add an offline validation flow so we can catch format/parameter issues without launching a browser.

### Main Changes

* **Pydantic v2 parameter models** (`browser_agent/actions/params.py`)

  * `OpenUrlParams(url: AnyHttpUrl)`
  * `WaitForParams(selector: NonEmptyStr, timeout_ms: 1..60000 | None=10000)`
  * `ClickParams(selector: NonEmptyStr)`
  * `TypeParams(selector: NonEmptyStr, text: <=4000)`
  * `ExtractTextParams(selector: NonEmptyStr)`
* **Registry upgrade** (`browser_agent/core/registry.py`)

  * `ActionMeta` (name + `params_model`)
  * `action(..., params_model=...)` decorator and `register()` API
  * `validate_spec(ActionSpec)`: unknown action → `KeyError`; invalid args → `ValidationError`
* **CLI offline validation** (`browser_agent/cli/main.py`)

  * New command: `browser-agent validate <specs.json>`
  * Two-layer checks: structure (`list[ActionSpec]`) + per-action Pydantic param validation
  * Non-zero exit code if any item fails (CI-friendly)
* **Quality / Tooling**

  * Added explicit return type hints for mypy strict mode
  * Fixed import order/formatting via ruff / ruff-format

### Motivation / Value

* Block bad parameters **before** hitting Playwright/CDP—fewer timeouts, mis-clicks, and flaky runs.
* Single source of truth for data contracts reusable by **CLI / orchestrator / future API**.
* Structured errors make logging, replay, and human-in-the-loop reviews straightforward.

### How to Verify

```bash
# 1) Quality gates
pre-commit run -a
pytest -q
mypy .

# 2) Offline validation example
cat > specs.json <<'JSON'
[
  {"name":"open_url","args":{"url":"https://example.com"}},
  {"name":"click","args":{"selector":""}},
  {"name":"unknown","args":{}}
]
JSON

browser-agent validate specs.json || echo "exit code=$?"
# Expected: open_url = OK; click = Invalid Args; unknown = Not Registered; exit code = 1
```

### Compatibility / Risk

* No breaking changes; all additions are backward compatible.
* Note: real action implementations are not yet registered—after D3, `validate` will check against the actual registered actions.

### Next Steps

* D3: Implement and register `open_url / wait_for / click / type / extract_text`.
* Hook into the plan→act→observe loop; optional: add `--print-schema` to expose action param schemas.

### Checklist

* [x] `pre-commit` / `mypy` / local tests pass
* [ ] README updated with `validate` example
* [x] No secrets or sensitive data included

